### PR TITLE
Fix external posts table reference

### DIFF
--- a/database/migrations/006_add_gdrive_support.sql
+++ b/database/migrations/006_add_gdrive_support.sql
@@ -1,0 +1,62 @@
+-- Migration: Add Google Drive support
+-- Date: 2025-09-07
+-- Description: Extend allowed source types to include 'gdrive'
+
+-- 1) Update CHECK constraint for external_data_sources.source_type
+ALTER TABLE external_data_sources 
+DROP CONSTRAINT IF EXISTS external_data_sources_source_type_check;
+
+ALTER TABLE external_data_sources 
+ADD CONSTRAINT external_data_sources_source_type_check 
+CHECK (source_type IN ('telegram', 'whatsapp', 'email', 'slack', 'gdrive'));
+
+-- 2) Update CHECK constraint for external_posts.source_type (only if table exists)
+DO $$ 
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'external_posts') THEN
+        ALTER TABLE external_posts 
+        DROP CONSTRAINT IF EXISTS external_posts_source_type_check;
+
+        ALTER TABLE external_posts 
+        ADD CONSTRAINT external_posts_source_type_check 
+        CHECK (source_type IN ('telegram', 'whatsapp', 'email', 'slack', 'gdrive'));
+        
+        RAISE NOTICE 'Updated external_posts source_type constraint to include gdrive';
+    ELSE
+        RAISE NOTICE 'external_posts table does not exist, skipping constraint update';
+    END IF;
+END $$;
+
+-- 3) Update post_images.source constraint to include GDRIVE
+ALTER TABLE post_images 
+DROP CONSTRAINT IF EXISTS post_images_source_check;
+
+ALTER TABLE post_images 
+ADD CONSTRAINT post_images_source_check 
+CHECK (source IN ('APP_UPLOAD', 'TELEGRAM', 'WHATSAPP', 'EMAIL', 'SLACK', 'GDRIVE', 'API', 'IMPORT'));
+
+-- 4) Check if posts table has source_type and update it too (for shared posts table)
+DO $$ 
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'posts' 
+        AND column_name = 'source_type'
+    ) THEN
+        -- No direct constraint on posts.source_type usually, but we can add a comment
+        COMMENT ON COLUMN posts.source_type IS 'Source of the post: app, telegram, whatsapp, email, slack, gdrive, etc.';
+        RAISE NOTICE 'Updated posts.source_type column comment to include gdrive';
+    ELSE
+        RAISE NOTICE 'posts table does not have source_type column';
+    END IF;
+END $$;
+
+-- 5) Comments
+COMMENT ON CONSTRAINT external_data_sources_source_type_check ON external_data_sources 
+IS 'Source types supported: telegram, whatsapp, email, slack, gdrive';
+
+COMMENT ON CONSTRAINT post_images_source_check ON post_images 
+IS 'Image sources: APP_UPLOAD, TELEGRAM, WHATSAPP, EMAIL, SLACK, GDRIVE, API, IMPORT';
+
+-- 6) Summary
+SELECT 'Google Drive support migration completed!' as status;


### PR DESCRIPTION
Add Google Drive support by updating source type constraints and comments, making updates conditional to prevent errors if `external_posts` table is missing and ensuring the main `posts` table is also updated.

The original migration failed with "relation 'external_posts' does not exist" because the table might not be present in all database setups. This PR modifies the migration to conditionally apply updates to `external_posts` and includes logic to update the `posts` table's `source_type` comment, accommodating scenarios where a single `posts` table is used for all post types.

---
<a href="https://cursor.com/background-agent?bcId=bc-1990508f-e37a-4f67-8e0a-3b45e81994a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1990508f-e37a-4f67-8e0a-3b45e81994a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

